### PR TITLE
Add lowercase command support to DOGESEND

### DIFF
--- a/COBOL/DOGESEND
+++ b/COBOL/DOGESEND
@@ -87,14 +87,15 @@
            END-EXEC.
        PARSE-INPUT.
       *    Do we want to leave this screen? 
-           IF OPTIONI EQUAL TO 'T' OR OPTIONI EQUAL TO 'M'
+           IF OPTIONI EQUAL TO 'T' OR OPTIONI EQUAL TO 't'
+      -       OR OPTIONI EQUAL TO 'M' OR OPTIONI EQUAL TO 'm'
                MOVE 'Opening Transaction History' TO WTO-MESSAGE
                PERFORM DOGE-WTO
                EXEC CICS XCTL 
                    PROGRAM('DOGETRAN')
                END-EXEC
            ELSE
-           IF OPTIONI EQUAL TO 'W'         
+           IF OPTIONI EQUAL TO 'W' OR OPTIONI EQUAL TO 'w'
                MOVE 'Opening Main Menu' TO WTO-MESSAGE
                PERFORM DOGE-WTO
                MOVE 'W' TO DOGECOMMS-AREA
@@ -103,7 +104,7 @@
                    COMMAREA(DOGECOMMS-AREA)
                END-EXEC
            ELSE
-           IF OPTIONI EQUAL TO 'S'
+           IF OPTIONI EQUAL TO 'S' OR OPTIONI EQUAL TO 's'
                MOVE 'Opening Such Send' TO WTO-MESSAGE
                PERFORM DOGE-WTO
            ELSE

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ Ok, *phew* that was a lot of changes. But we're not done yet.
 
 7. Edit `SYS1.PARMLIB(STARTSTD)` (using the same method described above) and add `CMD $SPRT4` to the line below `CMD $SPRT3` (this makes sure the printer is started on IPL)
 
-8. Edit `SYS1.PARMLIB(SHUTDOWN)`, `SYS1.PARMLIB(SHUTFAST)`, and `SYS1.PARMLIB(SHUTNOW)` (using the same method described above) and add `$PPRT4` to the line below `$PPRT3` (this makes sure the printer is stopped on shutdown)
+8. Edit `SYS1.PARMLIB(SHUTDOWN)`, `SYS1.PARMLIB(SHUTFAST)`, and `SYS1.PARMLIB(SHUTNOW)` (using the same method described above) and add `CMD $P PRT4` to the line below `CMD $P PRT3` (this makes sure the printer is stopped on shutdown)
 
 Okay, we're done with **tk4-** surgery. The rest is easy. 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,16 +32,13 @@ Next, boot **tk4-** with the `./mvs` command in linux. Once its loaded, use `x32
 
 Next we're going to make the following changes:
 
-1. Change `&MAXPART=6` to `&MAXPART=7`
-2. Change `&NUMPRTS=3` to `&NUMPRTS=4`
+1. Change `&MAXPART=6` to `&MAXPART=7` (This adds another initiator)
+2. Change `&NUMPRTS=3` to `&NUMPRTS=4` (This increases the number of printers)
 
-(these increase the number of printers)
+3. Change `I6       START,NAME=6,CLASS=SC` to `I6       START,NAME=6,CLASS=SCD` (this includes CLASS D to initiator 6 on startup)
 
-4. Change `I6       START,NAME=6,CLASS=SC` to `I6       START,NAME=6,CLASS=SCD`
+4. Underneath the following line: 
 
-(includes CLASS D in the initiators on startup)
-
-5. Underneath the following: 
 ```
 &C       NOJOURN,LOG,OUTPUT,PROCLIB=00,PERFORM=1, KICKS single thread  C
                CONVPARM=00000100099930E00011                            
@@ -53,13 +50,13 @@ add
 &D       NOJOURN,LOG,OUTPUT,PROCLIB=00,PERFORM=1, DOGE Output          C
                CONVPARM=00000100099930E00011                            
 ```
-(This includes Class D)
+(This creates a Class D for output)
 
-6. Then add the following below the `PRINTER3` line:
+5. Add the following below the `PRINTER3` line:
 
 ```
-PRINTER4       CLASS=D,SEP,AUTO,DSPLTCEL,NOPAUSE,UNIT=10E,DRAIN,       +
-               UCS=QN,FCB=6                                             
+PRINTER4       CLASS=D,SEP,AUTO,DSPLTCEL,NOPAUSE,UNIT=10E,START,       +
+               UCS=QN,FCB=6,FORMS=0001                                             
 ```
 
 So that it looks like this:
@@ -77,15 +74,15 @@ PRINTER4       CLASS=D,SEP,AUTO,DSPLTCEL,NOPAUSE,UNIT=10E,START,       +
 
 (This adds the actual printer)
 
-7. Change `$$D PRINT,SYSOUT,HOLD                HOLD - SYSOUT` to `$$D PRINT,SYSOUT,NOHOLD,TRKCEL      DOGE Printer for DOGECICS` 
+6. Change the line: `$$D PRINT,SYSOUT,HOLD                HOLD - SYSOUT` to `$$D PRINT,SYSOUT,NOHOLD,TRKCEL      DOGE Printer for DOGECICS` 
 
 (This changes the message class)
 
 Ok, *phew* that was a lot of changes. But we're not done yet. 
 
-Edit `SYS1.PARMLIB(STARTSTD)` (using the same method described above) and add `CMD $SPRT4` to the line below `CMD $SPRT3`
+7. Edit `SYS1.PARMLIB(STARTSTD)` (using the same method described above) and add `CMD $SPRT4` to the line below `CMD $SPRT3` (this makes sure the printer is started on IPL)
 
-(this makes sure the printer is started on IPL)
+8. Edit `SYS1.PARMLIB(SHUTDOWN)`, `SYS1.PARMLIB(SHUTFAST)`, and `SYS1.PARMLIB(SHUTNOW)` (using the same method described above) and add `$PPRT4` to the line below `$PPRT3` (this makes sure the printer is stopped on shutdown)
 
 Okay, we're done with **tk4-** surgery. The rest is easy. 
 


### PR DESCRIPTION
The RECEIVE MAP in DOGESEND uses "ASIS" in order to properly get lowercase letters for the sending address.

This has a side effect of requiring uppercase command letter input to switch screens. (W)ow works, (w)ow does not, but this works on all other screens.

This change adds simple comparison for lowercase command input to switch screens instead of silently failing.


This PR also picked up some text changes to INSTALL.md that I was going to submit under a second PR so you could take them individually,  but they seemed to get bundled in here.